### PR TITLE
Fix issue with sub directories getting flatten

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,9 +11,12 @@ import type { ResolvedOptions, UserOptions } from './types'
 export default function generateSitemap(options: UserOptions = {}) {
   const resolvedOptions: ResolvedOptions = resolveOptions(options)
   const routes = [
-    ...glob.sync('**/*.html', { cwd: resolvedOptions.outDir }).map(route => (
-      join('/', parse(route.replace(/index\.html/g, '')).name)
-    )),
+    ...glob.sync('**/*.html', { cwd: resolvedOptions.outDir }).map((route) => {
+      const parsedRoute = parse(route.replace(/index\.html/g, ''))
+      return (
+        join('/', parsedRoute.dir, parsedRoute.name)
+      )
+    }),
     ...resolvedOptions.dynamicRoutes.map(route => ensurePrefix('/', parse(route).name)),
   ]
   if (!routes.length) return

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,11 +1,11 @@
-import { existsSync, readFileSync, writeFileSync } from 'fs'
-import { resolve } from 'path'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { dirname, resolve } from 'path'
 import { describe, expect, test } from 'vitest'
 import format from 'xml-formatter'
 
 import generateSitemap, { getFinalSitemapPath, getFormattedSitemap, getResolvedPath, writeRobotFile, writeXmlFile } from '../src'
 import { resolveOptions } from '../src/options'
-import { ROBOTS_FILE, SITEMAP_FILE, TEST_FILE } from './variables'
+import { ROBOTS_FILE, SITEMAP_FILE, TEST_FILES } from './variables'
 
 describe('Index', () => {
   test('Generate sitemap', async() => {
@@ -17,7 +17,13 @@ describe('Index', () => {
     expect(existsSync(SITEMAP_FILE)).toBe(false)
     expect(existsSync(ROBOTS_FILE)).toBe(false)
 
-    writeFileSync(TEST_FILE, '')
+    TEST_FILES.forEach((testFile) => {
+      const folder = dirname(testFile)
+      if (!existsSync(folder))
+        mkdirSync(folder)
+      writeFileSync(testFile, '')
+    })
+
     const options = {
       dynamicRoutes: ['/'],
       allowRobots: false,

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,12 +1,15 @@
-import { existsSync, rmSync } from 'fs'
+import { existsSync, rmSync, rmdirSync } from 'fs'
 import { afterEach, beforeAll } from 'vitest'
 
-import { ROBOTS_FILE, SITEMAP_FILE, TEST_FILE } from './variables'
+import { ROBOTS_FILE, SITEMAP_FILE, SUBPATH_FOLDER, TEST_FILES } from './variables'
 
 const removeFiles = () => {
   if (existsSync(SITEMAP_FILE)) rmSync(SITEMAP_FILE)
   if (existsSync(ROBOTS_FILE)) rmSync(ROBOTS_FILE)
-  if (existsSync(TEST_FILE)) rmSync(TEST_FILE)
+  TEST_FILES.forEach((testFile) => {
+    if (existsSync(testFile)) rmSync(testFile)
+  })
+  if (existsSync(SUBPATH_FOLDER)) rmdirSync(SUBPATH_FOLDER)
 }
 
 beforeAll(() => {

--- a/test/variables.ts
+++ b/test/variables.ts
@@ -1,3 +1,4 @@
 export const ROBOTS_FILE = 'dist/robots.txt'
 export const SITEMAP_FILE = 'dist/sitemap.xml'
-export const TEST_FILE = 'dist/test.html'
+export const TEST_FILES = ['dist/test.html', 'dist/sub-path/index.html', 'dist/sub-path/deeper-path.html']
+export const SUBPATH_FOLDER = 'dist/sub-path/'


### PR DESCRIPTION
Fix subdirectories getting copied from public directory getting flattened and handling files different than index.html, for example inside public:
path/index.html
path/a.html
path/b.html

Will get transformed to in the sitemap.xml to:
localhost/path
localhost/a
localhost/b

it should be:
localhost/path
localhost/path/a
localhost/path/b

